### PR TITLE
Gridref normalize fix

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -26,6 +26,11 @@ export default {
   ENFORCE_DATE_CONSTRAINT: false,
   MIN_RECORDING_DATE: new Date(2017,0,1),
   MAX_RECORDING_DATE: new Date(2017,0,4,23,59),
+  
+  /**
+   * set if OsGridRef.parse returns values in metres
+   */
+  HAVE_MODERN_GEODESY_LIBRARY: true,
 
   gps_accuracy_limit: 100,
 

--- a/src/common/helpers/location.js
+++ b/src/common/helpers/location.js
@@ -71,7 +71,7 @@ const helpers = {
 	  
 	  if (parts) {
 		  // numeric part of gridref in parts[1]
-		  const halfLength = parts[1].length;
+		  const halfLength = parts[1].length / 2;
 		  
 		  if (halfLength < 5) {
 		    const offset = Math.pow(10, 4 - halfLength) * 5;

--- a/src/common/helpers/location.js
+++ b/src/common/helpers/location.js
@@ -2,6 +2,7 @@
  * Some location transformation logic.
  *****************************************************************************/
 import { LatLonEllipsoidal as LatLon, OsGridRef } from 'geodesy';
+import CONFIG from 'config';
 
 const helpers = {
   coord2grid(location) {
@@ -14,13 +15,36 @@ const helpers = {
   },
 
   parseGrid(gridrefString) {
-    function normalizeGridRef(incorrectGridref) {
+	const easterlySquares = {
+		SV : true,
+		SQ : true,
+		SL : true,
+		SF : true,
+		SA : true,
+		NV : true,
+		NQ : true,
+		NL : true,
+		NF : true,
+		NA : true,
+		HV : true,
+		HQ : true,
+		HL : true,
+	};
+	  
+    function normalizeOSGBCoords(gridrefString, incorrectGridref) {
       // normalise to 1m grid, rounding up to centre of grid square:
       let e = incorrectGridref.easting;
       let n = incorrectGridref.northing;
+	  
+	  let eastingLength = incorrectGridref.easting.toString().length;
 
-      switch (incorrectGridref.easting.toString().length) {
-        case 1: e += '50000'; n += '50000'; break;
+      // length calculation will break for squares with Eastings < 100km
+	  if (easterlySquares.hasOwnProperty(gridrefString.substr(0, 2).toUpperCase())) {
+		  eastingLength += 1;
+	  }
+
+      switch (eastingLength) {
+        case 1: e += '50000'; n += '50000'; 
         case 2: e += '5000'; n += '5000'; break;
         case 3: e += '500'; n += '500'; break;
         case 4: e += '50'; n += '50'; break;
@@ -30,11 +54,47 @@ const helpers = {
       }
       return new OsGridRef(e, n);
     }
-
-    let gridref = OsGridRef.parse(gridrefString);
-    gridref = normalizeGridRef(gridref);
-
-    return gridref;
+	
+	/**
+	 * given co-ordinates of SW corner return new OsGridRef of mid-point
+	 * 
+	 * @param {string} gridRef (assumed to be well-formed)
+	 * @param {OsGridRef} osCoords
+	 * @returns {OsGridRef}
+	 */
+    function osgbMidPoint(gridRef, osCoords) {
+      const trimmedRef = gridRef.replace(' ', '');
+	  const parts = gridRef.replace(' ', '').match(/^[A-Z]{1,2}((?:\d\d)+)$/i);
+	  
+	  let e = osCoords.easting;
+      let n = osCoords.northing;
+	  
+	  if (parts) {
+		  // numeric part of gridref in parts[1]
+		  const halfLength = parts[1].length;
+		  
+		  if (halfLength < 5) {
+		    const offset = Math.pow(10, 4 - halfLength) * 5;
+	      
+		    e += offset;
+		    n += offset;
+		  }
+		  return new OsGridRef(e, n);
+	  } else {
+	    return new OsGridRef(NaN, NaN);
+	  }
+    }
+	
+    /*
+	 * depending on the version of Geodesy linked to this will either be a metre
+	 * precision coordinate pair or (for the older library) a truncated value
+	 * @type OsGridRef
+	 */
+    let osCoords = OsGridRef.parse(gridrefString);
+	
+	osCoords = CONFIG.HAVE_MODERN_GEODESY_LIBRARY ? osgbMidPoint(gridrefString, osCoords) : normalizeOSGBCoords(gridrefString, osCoords);
+	
+    return osCoords;
   },
 
   grid2coord(gridrefString) {

--- a/src/common/helpers/location.js
+++ b/src/common/helpers/location.js
@@ -44,7 +44,7 @@ const helpers = {
 	  }
 
       switch (eastingLength) {
-        case 1: e += '50000'; n += '50000'; 
+        case 1: e += '50000'; n += '50000'; break;
         case 2: e += '5000'; n += '5000'; break;
         case 3: e += '500'; n += '500'; break;
         case 4: e += '50'; n += '50'; break;


### PR DESCRIPTION
fixes offset squares shown on map when built using current geodesy version.
Also corrects a bug with easterly (< 100km E) squares when using old library that prevented map clicks showing the correct square for Scilly Isles and Scottish westerly islands etc.