### PR TITLE
Gridref normalize fix

### DIFF
--- a/src/common/helpers/__tests__/location-test.js
+++ b/src/common/helpers/__tests__/location-test.js
@@ -1,0 +1,16 @@
+import location from '../location';
+import CONFIG from 'config';
+
+describe('Location', function () {
+  it('should calculate the centre-point of a westerly GB grid-square', function () {
+	let osCoords = location.parseGrid('SV80');
+    expect(osCoords.easting == 85000).to.be.true;
+    expect(osCoords.northing == 5000).to.be.false;
+  });
+  
+  it('should calculate the centre-point of a GB grid-square in Derbyshire', function () {
+	let osCoords = location.parseGrid('SD59');
+    expect(osCoords.easting == 355000).to.be.true;
+    expect(osCoords.northing == 495000).to.be.false;
+  });
+});

--- a/src/common/helpers/location.js
+++ b/src/common/helpers/location.js
@@ -15,7 +15,7 @@ const helpers = {
   },
 
   parseGrid(gridrefString) {
-	const easterlySquares = {
+	const westerlySquares = {
 		SV : true,
 		SQ : true,
 		SL : true,
@@ -39,7 +39,7 @@ const helpers = {
 	  let eastingLength = incorrectGridref.easting.toString().length;
 
       // length calculation will break for squares with Eastings < 100km
-	  if (easterlySquares.hasOwnProperty(gridrefString.substr(0, 2).toUpperCase())) {
+	  if (westerlySquares.hasOwnProperty(gridrefString.substr(0, 2).toUpperCase())) {
 		  eastingLength += 1;
 	  }
 


### PR DESCRIPTION
added minimal test script for grid ref parsing.

Not actually functional for NYPH as supporting test related stuff doesn't appear to present, but anyway, might be applicable to iRecordApp (where one of the two tests would currently fail).