### PR TITLE
Taxon suggestions re-show 'unknown plant'

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -13,9 +13,10 @@ export default {
 
   UNKNOWN_SPECIES: {
     id: 125442, //Plantae kingdom
-    scientific_name: 'Unknown Flowering Plant',
-    found_in_name: 'scientific_name'
+    scientific_name: 'Unknown flowering plant',
+    found_in_name: 'scientific_name',
   },
+  ALLOW_UNKNOWN_SPECIES: true,
   /**
    * if set then the most recently submitted location is auto-locked
    */

--- a/src/common/pages/taxon/main_view.js
+++ b/src/common/pages/taxon/main_view.js
@@ -238,8 +238,8 @@ export default Marionette.View.extend({
             // let controller know
             that.trigger('taxon:searched', text.toLowerCase());
           }, 100);
-        } else if ((text.replace(/\.|\s/g, '').length) === 0) {
-			// no text at all
+        } else if (CONFIG.ALLOW_UNKNOWN_SPECIES && (text.replace(/\.|\s/g, '').length === 0)) {
+			// no search text, but pass through search, so that 'Unknown sp' can be shown
 			
 			// Clear previous timeout
           if (this.timeout !== -1) {

--- a/src/common/pages/taxon/main_view.js
+++ b/src/common/pages/taxon/main_view.js
@@ -276,7 +276,20 @@ export default Marionette.View.extend({
             // let controller know
             that.trigger('taxon:searched', text.toLowerCase());
           }, 100);
-        }
+        } else if ((text.replace(/\.|\s/g, '').length) === 0) {
+			// no text at all
+			
+			// Clear previous timeout
+          if (this.timeout !== -1) {
+            clearTimeout(this.timeout);
+          }
+
+          // Set new timeout - don't run if user is typing
+          this.timeout = setTimeout(function () {
+            // let controller know
+            that.trigger('taxon:searched', '');
+          }, 100);
+		}
     }
   },
 });

--- a/src/common/pages/taxon/main_view.js
+++ b/src/common/pages/taxon/main_view.js
@@ -238,7 +238,20 @@ export default Marionette.View.extend({
             // let controller know
             that.trigger('taxon:searched', text.toLowerCase());
           }, 100);
-        }
+        } else if ((text.replace(/\.|\s/g, '').length) === 0) {
+			// no text at all
+			
+			// Clear previous timeout
+          if (this.timeout !== -1) {
+            clearTimeout(this.timeout);
+          }
+
+          // Set new timeout - don't run if user is typing
+          this.timeout = setTimeout(function () {
+            // let controller know
+            that.trigger('taxon:searched', '');
+          }, 100);
+		}
     }
     return null;
   },
@@ -276,20 +289,7 @@ export default Marionette.View.extend({
             // let controller know
             that.trigger('taxon:searched', text.toLowerCase());
           }, 100);
-        } else if ((text.replace(/\.|\s/g, '').length) === 0) {
-			// no text at all
-			
-			// Clear previous timeout
-          if (this.timeout !== -1) {
-            clearTimeout(this.timeout);
-          }
-
-          // Set new timeout - don't run if user is typing
-          this.timeout = setTimeout(function () {
-            // let controller know
-            that.trigger('taxon:searched', '');
-          }, 100);
-		}
+        }
     }
   },
 });

--- a/src/common/pages/taxon/search/taxon_search_engine.js
+++ b/src/common/pages/taxon/search/taxon_search_engine.js
@@ -7,6 +7,7 @@ import { Log } from 'helpers';
 import searchCommonNames from './commonNamesSearch';
 import searchSciNames from './scientificNamesSearch';
 import helpers from './searchHelpers';
+import CONFIG from 'config';
 
 let species;
 let loading = false;
@@ -62,8 +63,14 @@ const API = {
 
     //if (!searchPhrase) return results;
 	if (!searchPhrase) {
-		callback([]);
-		return [];
+      results.push({
+	    warehouse_id: CONFIG.UNKNOWN_SPECIES.id, // is it correct to map 'warehouse_id' to 'id'?
+	    scientific_name: CONFIG.UNKNOWN_SPECIES.scientific_name,
+        found_in_name: CONFIG.UNKNOWN_SPECIES.found_in_name,
+	  });
+		
+	  callback(results);
+	  return;
 	}
 
     // normalize the search phrase

--- a/src/common/pages/taxon/search/taxon_search_engine.js
+++ b/src/common/pages/taxon/search/taxon_search_engine.js
@@ -63,11 +63,12 @@ const API = {
 
     //if (!searchPhrase) return results;
 	if (!searchPhrase) {
-      results.push({
-	    warehouse_id: CONFIG.UNKNOWN_SPECIES.id, // is it correct to map 'warehouse_id' to 'id'?
-	    scientific_name: CONFIG.UNKNOWN_SPECIES.scientific_name,
-        found_in_name: CONFIG.UNKNOWN_SPECIES.found_in_name,
-	  });
+      //results.push({
+	  //  species_id: CONFIG.UNKNOWN_SPECIES.id, // is it correct to map 'warehouse_id' or 'species_id' to 'id'?
+	  //  scientific_name: CONFIG.UNKNOWN_SPECIES.scientific_name,
+      //  found_in_name: CONFIG.UNKNOWN_SPECIES.found_in_name,
+	  //});
+	  results.push(Object.assign({}, CONFIG.UNKNOWN_SPECIES));
 		
 	  callback(results);
 	  return;

--- a/src/common/pages/taxon/search/taxon_search_engine.js
+++ b/src/common/pages/taxon/search/taxon_search_engine.js
@@ -60,7 +60,10 @@ const API = {
 
     let results = [];
 
-    if (!searchPhrase) return results;
+    //if (!searchPhrase) return results;
+	if (!searchPhrase) {
+		callback(results);
+	}
 
     // normalize the search phrase
     const normSearchPhrase = searchPhrase.toLowerCase();

--- a/src/common/pages/taxon/search/taxon_search_engine.js
+++ b/src/common/pages/taxon/search/taxon_search_engine.js
@@ -61,16 +61,11 @@ const API = {
 
     let results = [];
 
-    //if (!searchPhrase) return results;
 	if (!searchPhrase) {
-      //results.push({
-	  //  species_id: CONFIG.UNKNOWN_SPECIES.id, // is it correct to map 'warehouse_id' or 'species_id' to 'id'?
-	  //  scientific_name: CONFIG.UNKNOWN_SPECIES.scientific_name,
-      //  found_in_name: CONFIG.UNKNOWN_SPECIES.found_in_name,
-	  //});
-	  results.push(Object.assign({}, CONFIG.UNKNOWN_SPECIES));
-		
-	  callback(results);
+      if (CONFIG.ALLOW_UNKNOWN_SPECIES) {
+        results.push(Object.assign({}, CONFIG.UNKNOWN_SPECIES));
+	    callback(results);
+	  }
 	  return;
 	}
 

--- a/src/common/pages/taxon/search/taxon_search_engine.js
+++ b/src/common/pages/taxon/search/taxon_search_engine.js
@@ -62,7 +62,8 @@ const API = {
 
     //if (!searchPhrase) return results;
 	if (!searchPhrase) {
-		callback(results);
+		callback([]);
+		return [];
 	}
 
     // normalize the search phrase


### PR DESCRIPTION
When user has blanked out taxon query (i.e. by typing, then deleting) show 'Unknown flowering plant' as a suggestion, rather than retaining the previous list of suggestions. 

This provides a way to redisplay the link to 'Unknown plant', which is otherwise lost once typing starts.

Am not completely sold on this approach, as it fails to redisplay the message about needing a photo, but think it's still better than nothing.