### PR TITLE
Submit as gridref

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -95,13 +95,13 @@ export default {
           options.flattener(attributes, options);
 
           // for NYPH base unit should always be grid-reference rather that lat/lng
-          return location.gridref;
+          return location.gridref ? location.gridref : location.latitude + ', ' + location.longitude;
         },
       },
       location_type: {
           values(location) {
             // this should eventually also accomodate Irish gridrefs
-            return 'OSGB';
+            return location.gridref ? 'OSGB' : 4326;
           },
       },
       location_accuracy: { id: 282 },

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -94,12 +94,13 @@ export default {
           // add other location related attributes
           options.flattener(attributes, options);
 
-          //return location.latitude + ', ' + location.longitude;
+          // for NYPH base unit should always be grid-reference rather that lat/lng
           return location.gridref;
         },
       },
       location_type: {
           values(location) {
+            // this should eventually also accomodate Irish gridrefs
             return 'OSGB';
           },
       },

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -94,8 +94,14 @@ export default {
           // add other location related attributes
           options.flattener(attributes, options);
 
-          return location.latitude + ', ' + location.longitude;
+          //return location.latitude + ', ' + location.longitude;
+          return location.gridref;
         },
+      },
+      location_type: {
+          values(location) {
+            return 'OSGB';
+          },
       },
       location_accuracy: { id: 282 },
       location_altitude: { id: 283 },

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -43,7 +43,7 @@ export default {
 
   // mapping
   map: {
-    os_api_key: '28994B5673A86451E0530C6CA40A91A5',
+    os_api_key: '3AE71B01F6EE4829E0530C6CA40A35B3',
     mapbox_api_key: 'pk.eyJ1IjoiY2VoYXBwcyIsImEiOiJjaXBxdTZyOWYwMDZoaWVuYjI3Y3Z0a2x5In0.YXrZA_DgWCdjyE0vnTCrmw',
     mapbox_osm_id: 'cehapps.0fenl1fe',
     mapbox_satellite_id: 'cehapps.0femh3mh',


### PR DESCRIPTION
Change makes behaviour of the app consistent with how irecord normally commits records,
using 'entered_sref' for both lat/long pairs or for OS gridref strings
the interpretation of the field is determined by 'entered_sref_system' which default to a lat/lng interpretation.

The app currently always provides lat/lng and doesn't set 'entered_sref_system'.

The change provides a gridref for 'entered_sref' and OSGB as the system.  This is correct for NYPH (becuase Irish refs aren't yet being handled anyway) and although in an ideal world GPS refs might be better treated as lat/lng, for current purposes users will expect to see grid-refs.  Almost on-one uses lat/lng for botanical recording in the UK.